### PR TITLE
Fix: Excessive log in status channel

### DIFF
--- a/bye.pl
+++ b/bye.pl
@@ -8,7 +8,6 @@ use Irssi;
 # Función que se llama cuando alguien habla en el canal
 sub response {
     my ($server, $message, $nick, $address, $channel) = @_;
-    Irssi::print("mensaje: $message");
     if ($message =~ /^!adios$/i) {
         # Envía un mensaje de respuesta al canal donde se envió el comando
         $server->command("msg $channel Hasta la proxima, $nick!");


### PR DESCRIPTION
Removed "Irssi::print("mensaje: $message");" to prevent messages heard by irssi from being displayed in the status channel